### PR TITLE
fix: Python 3.11 f-string backslash regression (restores daily deploy)

### DIFF
--- a/scripts/cmmc_page_generator.py
+++ b/scripts/cmmc_page_generator.py
@@ -1026,6 +1026,17 @@ def build_cmmc_page(
         ),
     }
 
+    # Hero background div. Built here (not inline in the f-string below) because
+    # the CSS url("...") needs escaped double quotes, and a backslash is illegal
+    # inside an f-string expression on Python 3.11 (the CI runtime).
+    hero_image_div = ""
+    if hero_image_url:
+        hero_image_div = (
+            "<div class='cmmc-hero-image' style='background-image: url(\""
+            + safe_css_url(hero_image_url)
+            + "\");'></div>"
+        )
+
     # Build complete HTML
     html = f"""<!DOCTYPE html>
 <html lang="en" class="dark-mode">
@@ -1057,7 +1068,7 @@ def build_cmmc_page(
     {build_cmmc_header(date_str)}
 
     <section class="cmmc-hero">
-        {"<div class='cmmc-hero-image' style='background-image: url(\"" + safe_css_url(hero_image_url) + "\");'></div>" if hero_image_url else ""}
+        {hero_image_div}
         <div class="cmmc-hero-overlay"></div>
         <div class="cmmc-hero-content">
             <span class="cmmc-hero-badge">{featured_source or 'CMMC News'}</span>


### PR DESCRIPTION
Hotfix for the regression from #33 that broke the daily deploy.

**Cause:** `cmmc_page_generator.py` interpolated a CSS `url(\"...\")` (escaped double quotes) inline in an f-string. Legal on Python 3.12 (my local venv, where py_compile passed) but a `SyntaxError` on Python 3.11 (the CI runtime) — so `main.py`'s import chain failed and the pipeline aborted both attempts (the new retry fired but couldn't help a syntax error).

**Fix:** build the hero `<div>` in a plain statement before the f-string.

**Verified:** all `scripts/*.py` compile under real Python 3.11 (`uv run --python 3.11 -- python -m py_compile scripts/*.py`), 514 tests pass, mypy clean. Added an AST check confirming no f-string expression anywhere contains a backslash.