### PR TITLE
docs: document CI test gate + 3.11/3.12 runtime

### DIFF
--- a/.claude/rules/config.md
+++ b/.claude/rules/config.md
@@ -17,6 +17,7 @@ Required in `.env` or GitHub Secrets:
 - `SITE_URL` / `SITE_NAME` - Canonical base URL + brand name (single source of truth; `RSS_FEED_LINK`/`RSS_FEED_TITLE` derive from them)
 
 ## GitHub Actions
+- `ci.yml` - PR + push to main: py_compile + pytest + mypy on Python 3.11 & 3.12 (required status checks on `main`). CI runs 3.11; local `.venv` is 3.12 — verify f-string syntax under 3.11 before merging.
 - `daily-regenerate.yml` - Daily 6AM EST
 - `auto-merge-claude.yml` - Auto PR merge for `claude/**` branches
 - `update-readme.yml` - Changelog updates

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,12 +135,15 @@ Single deterministic design profile ("Signal Desk") | Fixed layout (`newspaper`)
 
 Fixtures: `tests/conftest.py` (sample_trends, sample_images, sample_design) | APIs mocked | Extensive coverage in `test_design_system.py` | Run from project root
 
+**CI gate (`ci.yml`):** every PR + push to `main` runs `py_compile` + `pytest` + `mypy` on a Python **3.11 / 3.12** matrix; `test (py3.11)` and `test (py3.12)` are **required status checks** on `main`. **Runtime gotcha:** `.venv` is 3.12 but the pipeline deploys on **3.11** — PEP 701 f-string features (backslashes / quote reuse) compile locally yet break CI. Verify with `uv run --python 3.11 --no-project -- python -m py_compile scripts/*.py`. Tests reading gitignored `data/` runtime files must skip when absent.
+
 ## GitHub Workflows
 
 | Workflow | Trigger | Purpose |
 |----------|---------|---------|
+| `ci.yml` | PR, push main, manual | `py_compile` + `pytest` + `mypy` on Python 3.11 & 3.12; required status checks on `main` |
 | `daily-regenerate.yml` | Daily 6AM EST, push main, manual | Main pipeline → deploy to Pages; opens issue on failure |
-| `auto-merge-claude.yml` | Push `claude/**` | Auto-creates PR and squash-merges with `--admin` |
+| `auto-merge-claude.yml` | Push `claude/**` | Auto-creates PR and squash-merges (no `--admin`; respects branch protection — now gated by the required CI checks) |
 | `update-readme.yml` | Push main | Changelog update |
 | `source-health.yml` | Daily 11:30 UTC, manual | Runs `source_health_check.py`, commits `data/source_health.json` |
 | `competitor-monitor.yml` | Weekly Mon 9 UTC, manual | Runs `competitor_monitor.py`, opens issue on high-priority alerts |

--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ pytest tests/test_design_system.py  # Single test file
 
 | Workflow | Trigger | Purpose |
 |----------|---------|---------|
+| `ci.yml` | PR, push to main, manual | Tests + type check + compile on Python 3.11 & 3.12 (required on `main`) |
 | `daily-regenerate.yml` | Daily 6 AM EST, push to main, manual | Main pipeline → deploy to GitHub Pages |
 | `auto-merge-claude.yml` | Push to `claude/**` branches | Auto PR creation + squash-merge |
 | `update-readme.yml` | Push to main | Changelog updates |


### PR DESCRIPTION
Updates docs to reflect the new CI gate (#36) and the Python 3.11/3.12 runtime split. Also corrects a stale note that auto-merge-claude uses `--admin` (it no longer does). Doc-only change.