### PR TITLE
ci: auto-merge-claude uses --auto (waits for required checks)

### DIFF
--- a/.github/workflows/auto-merge-claude.yml
+++ b/.github/workflows/auto-merge-claude.yml
@@ -43,6 +43,8 @@ jobs:
             echo "PR #$EXISTING_PR already exists"
           fi
 
-          # Merge (squash). No --admin: respect branch protection / required
-          # checks if any are configured, instead of bypassing them.
-          gh pr merge "$BRANCH" --squash --delete-branch
+          # Enable auto-merge (squash). --auto queues the merge and lets it
+          # complete only once the required CI checks (test (py3.11/3.12)) pass,
+          # instead of merging immediately and racing the checks. No --admin:
+          # required checks actually gate the merge.
+          gh pr merge "$BRANCH" --auto --squash --delete-branch


### PR DESCRIPTION
Companion to the required-status-checks change. Switches auto-merge-claude.yml from an immediate `gh pr merge --squash` to `--auto --squash` so claude/** PRs merge only after `test (py3.11)` + `test (py3.12)` pass, instead of racing them.